### PR TITLE
fix: standardized margins/paddings and max-width

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import MaxWidthWrapper from "@/components/layout/MaxWidthWrapper";
 import NavBar from "@/components/layout/NavBar";
 import ArticlesToRead from "@/components/section/ArticlesToRead";
 import Cast from "@/components/section/Cast";
@@ -8,16 +9,18 @@ import MarvelTalk from "@/components/section/MarvelTalk";
 import SneakPeek from "@/components/section/SneakPeek";
 
 export default function Home() {
-	return (
-		<main className="w-screen h-full flex flex-col items-center">
-			<NavBar />
-			<HeroSection />
-			<SneakPeek />
-			<FindTickets />
-			<MarvelTalk />
-			<ArticlesToRead />
-			<Cast />
-			<Footer />
-		</main>
-	);
+  return (
+    <main className="w-full h-full">
+      <MaxWidthWrapper>
+        <NavBar />
+        <HeroSection />
+        <SneakPeek />
+        <FindTickets />
+        <MarvelTalk />
+        <ArticlesToRead />
+        <Cast />
+        <Footer />
+      </MaxWidthWrapper>
+    </main>
+  );
 }

--- a/components/layout/MaxWidthWrapper.tsx
+++ b/components/layout/MaxWidthWrapper.tsx
@@ -8,9 +8,7 @@ type Props = {
 
 function MaxWidthWrapper({ children, className }: Props) {
   return (
-    <div className={cn("max-w-screen-xl px-6 md:px-8 mx-auto", className)}>
-      {children}
-    </div>
+    <div className={cn("max-w-[1440px] mx-auto", className)}>{children}</div>
   );
 }
 

--- a/components/layout/NavBar.tsx
+++ b/components/layout/NavBar.tsx
@@ -6,81 +6,81 @@ import Link from "next/link";
 import Logo from "../elements/Logo";
 
 interface navText {
-	href: string;
-	text: string;
+  href: string;
+  text: string;
 }
 
 const navMenu: navText[] = [
-	{ href: "#home", text: "Home" },
-	{ href: "#marveltalk", text: "Reviews" },
-	{ href: "#article", text: "Article" },
-	{ href: "#cast", text: "Cast" },
+  { href: "#home", text: "Home" },
+  { href: "#marveltalk", text: "Reviews" },
+  { href: "#article", text: "Article" },
+  { href: "#cast", text: "Cast" },
 ];
 
 const NavBar: React.FC = () => {
-	const [toggleMenu, setToggleMenu] = useState(false);
+  const [toggleMenu, setToggleMenu] = useState(false);
 
-	return (
-		<section className="w-screen flex justify-center items-center fixed z-50">
-			<div className="w-11/12 h-[8rem] flex justify-between items-center">
-				<Logo />
+  return (
+    <section className="w-full flex justify-center items-center fixed z-50">
+      <div className="w-11/12 h-[8rem] flex justify-between items-center">
+        <Logo />
 
-				{/* Mobile and tablet view */}
-				<div className="md:w-6/12 md:hidden flex items-center px-3 gap-5 md:px-1">
-					<div>
-						<Phone />
-					</div>
-					<div className="flex flex-col">
-						<div
-							className="flex flex-col justify-between w-6 h-5 cursor-pointer"
-							onClick={() => setToggleMenu(!toggleMenu)}
-						>
-							{toggleMenu ? (
-								<X size={20} className="text-deadpool-primary" />
-							) : (
-								<>
-									<span className="block w-full h-[2px] bg-deadpool-primary rounded" />
-									<span className="block w-4/6 h-[2px] bg-deadpool-primary rounded ml-auto" />
-									<span className="block w-full h-[2px] bg-deadpool-primary rounded" />
-								</>
-							)}
-						</div>
-						{toggleMenu && (
-							<div className="flex flex-col mt-2 bg-deadpool-neutral rounded-md shadow-lg absolute top-20 right-8 w-15">
-								<ul className="flex flex-col gap-2 p-3">
-									{navMenu.map(({ href, text }, idx) => (
-										<li
-											key={idx}
-											className="hover:border-b-2 hover:text-deadpool-secondary border-deadpool-secondary"
-										>
-											<Link href={href}>{text}</Link>
-										</li>
-									))}
-								</ul>
-							</div>
-						)}
-					</div>
-				</div>
+        {/* Mobile and tablet view */}
+        <div className="md:w-6/12 md:hidden flex items-center px-3 gap-5 md:px-1">
+          <div>
+            <Phone />
+          </div>
+          <div className="flex flex-col">
+            <div
+              className="flex flex-col justify-between w-6 h-5 cursor-pointer"
+              onClick={() => setToggleMenu(!toggleMenu)}
+            >
+              {toggleMenu ? (
+                <X size={20} className="text-deadpool-primary" />
+              ) : (
+                <>
+                  <span className="block w-full h-[2px] bg-deadpool-primary rounded" />
+                  <span className="block w-4/6 h-[2px] bg-deadpool-primary rounded ml-auto" />
+                  <span className="block w-full h-[2px] bg-deadpool-primary rounded" />
+                </>
+              )}
+            </div>
+            {toggleMenu && (
+              <div className="flex flex-col mt-2 bg-deadpool-neutral rounded-md shadow-lg absolute top-20 right-8 w-15">
+                <ul className="flex flex-col gap-2 p-3">
+                  {navMenu.map(({ href, text }, idx) => (
+                    <li
+                      key={idx}
+                      className="hover:border-b-2 hover:text-deadpool-secondary border-deadpool-secondary"
+                    >
+                      <Link href={href}>{text}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
 
-				{/* Mid to larger viewport */}
-				<div className="hidden w-6/12 md:flex md:justify-evenly lg:justify-end items-center pr-2">
-					<ul className="xl:w-6/12 flex flex-row justify-between md:gap-4 xl:gap-3 p-3">
-						{navMenu.map(({ href, text }, idx) => (
-							<li
-								key={idx}
-								className="relative w-full hover:border-b-2 hover:text-deadpool-secondary border-deadpool-secondary text-center pb-1"
-							>
-								<Link href={href}>{text}</Link>
-							</li>
-						))}
-					</ul>
-					<Button variant="secondary" className="rounded-full">
-						Contact
-					</Button>
-				</div>
-			</div>
-		</section>
-	);
+        {/* Mid to larger viewport */}
+        <div className="hidden w-6/12 md:flex md:justify-evenly lg:justify-end items-center pr-2">
+          <ul className="xl:w-6/12 flex flex-row justify-between md:gap-4 xl:gap-3 p-3">
+            {navMenu.map(({ href, text }, idx) => (
+              <li
+                key={idx}
+                className="relative w-full hover:border-b-2 hover:text-deadpool-secondary border-deadpool-secondary text-center pb-1"
+              >
+                <Link href={href}>{text}</Link>
+              </li>
+            ))}
+          </ul>
+          <Button variant="secondary" className="rounded-full">
+            Contact
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default NavBar;

--- a/components/section/ArticlesToRead.tsx
+++ b/components/section/ArticlesToRead.tsx
@@ -130,7 +130,7 @@ export default function ArticlesToRead() {
 
   return (
     <div
-      className="w-screen flex flex-col text-deadpool-primary px-[25px] lg:px-[75px] py-7 tracking-tighter gap-[22px] lg:gap-7"
+      className="w-full flex flex-col text-deadpool-primary px-[25px] lg:px-[75px] py-7 tracking-tighter gap-[22px] lg:gap-7"
       id="article"
     >
       {articlesToReadWrapper}

--- a/components/section/Cast.tsx
+++ b/components/section/Cast.tsx
@@ -1,144 +1,163 @@
 "use client";
 import {
-	Pagination,
-	PaginationContent,
-	PaginationItem,
-	PaginationLink,
-	PaginationNext,
-	PaginationPrevious,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
 } from "@/components/ui/pagination";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import Image, { StaticImageData } from "next/image";
 import {
-	aaron,
-	blake,
-	chris,
-	dafne,
-	emma,
-	hugh,
-	leslie,
-	matthew,
-	ryan,
-	shioli,
+  aaron,
+  blake,
+  chris,
+  dafne,
+  emma,
+  hugh,
+  leslie,
+  matthew,
+  ryan,
+  shioli,
 } from "../constants/images";
 import { useState } from "react";
 
 type CastProps = {
-	img: StaticImageData;
-	castName: string;
-	castRole: string;
+  img: StaticImageData;
+  castName: string;
+  castRole: string;
 };
 
 const castMembers: CastProps[] = [
-	{ img: ryan, castName: "Ryan Reynolds", castRole: "Deadpool" },
-	{ img: hugh, castName: "Hugh Jackman", castRole: "Wolverine" },
-	{ img: emma, castName: "Emma Corrin", castRole: "Cassandra Nova" },
-	{ img: aaron, castName: "Aaron Stanford", castRole: "Pyro" },
-	{ img: matthew, castName: "Matthew Macfayden", castRole: "Mobius" },
-	{ img: shioli, castName: "Shioli Kutsuna", castRole: "Yukio" },
-	{ img: leslie, castName: "Leslie Uggams", castRole: "Blind Al" },
-	{ img: blake, castName: "Blake Lively", castRole: "Ladypool" },
-	{ img: chris, castName: "Chris Evans", castRole: "Johnny Storm" },
-	{ img: dafne, castName: "Dafne Keen", castRole: "Laura / X-23" },
+  { img: ryan, castName: "Ryan Reynolds", castRole: "Deadpool" },
+  { img: hugh, castName: "Hugh Jackman", castRole: "Wolverine" },
+  { img: emma, castName: "Emma Corrin", castRole: "Cassandra Nova" },
+  { img: aaron, castName: "Aaron Stanford", castRole: "Pyro" },
+  { img: matthew, castName: "Matthew Macfayden", castRole: "Mobius" },
+  { img: shioli, castName: "Shioli Kutsuna", castRole: "Yukio" },
+  { img: leslie, castName: "Leslie Uggams", castRole: "Blind Al" },
+  { img: blake, castName: "Blake Lively", castRole: "Ladypool" },
+  { img: chris, castName: "Chris Evans", castRole: "Johnny Storm" },
+  { img: dafne, castName: "Dafne Keen", castRole: "Laura / X-23" },
 ];
 
 const itemsPerPage = 5;
 
 function Cast() {
-	const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
 
-	const lastItemIdx = currentPage * itemsPerPage;
-	const firstItemIdx = lastItemIdx - itemsPerPage;
-	const currentItems = castMembers.slice(firstItemIdx, lastItemIdx);
+  const lastItemIdx = currentPage * itemsPerPage;
+  const firstItemIdx = lastItemIdx - itemsPerPage;
+  const currentItems = castMembers.slice(firstItemIdx, lastItemIdx);
 
-	const pageChangeHandler = (pageNumber: number): void => setCurrentPage(pageNumber);
+  const pageChangeHandler = (pageNumber: number): void =>
+    setCurrentPage(pageNumber);
 
-	const totalPages = Math.ceil(castMembers.length / itemsPerPage);
+  const totalPages = Math.ceil(castMembers.length / itemsPerPage);
 
-	return (
-		<section className="w-11/12 flex flex-col items-center justify-center" id="cast">
-			<div className="self-end text-right mb-8 max-w-3xl ml-auto pr-5">
-				<h1 className="text-3xl mb-2">Deadpool & Wolverine Cast</h1>
-				<p>
-					Meet the Star-Studded Lineup Bringing Your Favorite Characters to Life. Explore
-					the actors behind this iconic Marvel duo and their roles in the film.
-				</p>
-			</div>
-			<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
-				{currentItems.map(({ img, castName, castRole }, idx) => (
-					<Card
-						key={idx}
-						className="bg-deadpool-neutral border-none flex flex-col items-center"
-					>
-						<CardHeader className="flex justify-center">
-							<div className="relative w-[200px] h-[300px]">
-								<Image
-									src={img}
-									alt={castName}
-									layout="fill"
-									className="rounded-lg object-cover"
-								/>
-							</div>
-						</CardHeader>
-						<CardContent className="flex flex-col items-start relative w-[84.5%]">
-							<CardTitle className="text-deadpool-primary">{castName}</CardTitle>
-							<CardDescription>{castRole}</CardDescription>
-						</CardContent>
-					</Card>
-				))}
-			</div>
-			<Paginate
-				currentPage={currentPage}
-				totalPages={totalPages}
-				onPageChange={pageChangeHandler}
-			/>
-		</section>
-	);
+  return (
+    <section
+      className="w-11/12 flex flex-col items-center justify-center mx-auto"
+      id="cast"
+    >
+      <div className="self-end text-right mb-8 max-w-3xl ml-auto pr-5">
+        <h1 className="text-3xl mb-2">Deadpool & Wolverine Cast</h1>
+        <p>
+          Meet the Star-Studded Lineup Bringing Your Favorite Characters to
+          Life. Explore the actors behind this iconic Marvel duo and their roles
+          in the film.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6">
+        {currentItems.map(({ img, castName, castRole }, idx) => (
+          <Card
+            key={idx}
+            className="bg-deadpool-neutral border-none flex flex-col items-center"
+          >
+            <CardHeader className="flex justify-center">
+              <div className="relative w-[200px] h-[300px]">
+                <Image
+                  src={img}
+                  alt={castName}
+                  layout="fill"
+                  className="rounded-lg object-cover"
+                />
+              </div>
+            </CardHeader>
+            <CardContent className="flex flex-col items-start relative w-[84.5%]">
+              <CardTitle className="text-deadpool-primary">
+                {castName}
+              </CardTitle>
+              <CardDescription>{castRole}</CardDescription>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Paginate
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={pageChangeHandler}
+      />
+    </section>
+  );
 }
 
 type PaginateProps = {
-	currentPage: number;
-	totalPages: number;
-	onPageChange: (pageNumber: number) => void;
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (pageNumber: number) => void;
 };
 
-const Paginate: React.FC<PaginateProps> = ({ currentPage, totalPages, onPageChange }) => (
-	<Pagination>
-		<PaginationContent>
-			<PaginationItem>
-				<PaginationPrevious
-					href="#"
-					onClick={(e) => {
-						e.preventDefault();
-						onPageChange(currentPage > 1 ? currentPage - 1 : 1);
-					}}
-				/>
-			</PaginationItem>
-			{Array.from({ length: totalPages }, (_, idx) => (
-				<PaginationItem key={idx + 1}>
-					<PaginationLink
-						href="#"
-						onClick={(e) => {
-							e.preventDefault();
-							onPageChange(idx + 1);
-						}}
-						className={currentPage === idx + 1 ? "active" : ""}
-					>
-						{idx + 1}
-					</PaginationLink>
-				</PaginationItem>
-			))}
-			<PaginationItem>
-				<PaginationNext
-					href="#"
-					onClick={(e) => {
-						e.preventDefault();
-						onPageChange(currentPage < totalPages ? currentPage + 1 : totalPages);
-					}}
-				/>
-			</PaginationItem>
-		</PaginationContent>
-	</Pagination>
+const Paginate: React.FC<PaginateProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}) => (
+  <Pagination>
+    <PaginationContent>
+      <PaginationItem>
+        <PaginationPrevious
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            onPageChange(currentPage > 1 ? currentPage - 1 : 1);
+          }}
+        />
+      </PaginationItem>
+      {Array.from({ length: totalPages }, (_, idx) => (
+        <PaginationItem key={idx + 1}>
+          <PaginationLink
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              onPageChange(idx + 1);
+            }}
+            className={currentPage === idx + 1 ? "active" : ""}
+          >
+            {idx + 1}
+          </PaginationLink>
+        </PaginationItem>
+      ))}
+      <PaginationItem>
+        <PaginationNext
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            onPageChange(
+              currentPage < totalPages ? currentPage + 1 : totalPages
+            );
+          }}
+        />
+      </PaginationItem>
+    </PaginationContent>
+  </Pagination>
 );
 
 export default Cast;

--- a/components/section/FindTickets.tsx
+++ b/components/section/FindTickets.tsx
@@ -1,74 +1,81 @@
 import { Road_Rage } from "next/font/google";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import Image from "next/image";
-import { arrow, deadpoolWolverine, icon1, icon2, icon3, play } from "../constants/images";
+import {
+  arrow,
+  deadpoolWolverine,
+  icon1,
+  icon2,
+  icon3,
+  play,
+} from "../constants/images";
 import { Button } from "../ui/button";
 import { PlayIcon } from "lucide-react";
 
 const roadRage = Road_Rage({ subsets: ["latin"], weight: ["400"] });
 
 function FindTickets() {
-	return (
-		<section className="w-11/12 flex flex-col items-center">
-			<div className="flex flex-col">
-				<h1
-					className={`${roadRage.className} text-5xl md:text-7xl lg:text-9xl text-center`}
-				>
-					<span className="text-deadpool-accent">DEADPOOL</span> &{" "}
-					<span className="text-deadpool-secondary">WOLVERINE</span> IS JUST THE BLOODY,
-					PUERILE, HEARTFELT MOVIE WE WANTED
-				</h1>
-				<p className="text-left md:text-right text-deadpool-body relative self-start md:self-end md:mr-[7.4%]">
-					by Kyle Anderson
-				</p>
-			</div>
-			<div className="flex justify-center items-center">
-				<div className="hidden absolute xl:flex w-[700px] h-[700px] border-2 border-deadpool-body rounded-full bg-transparent items-center justify-center 2xl:-left-[20rem] 2xl:top-[1780px] xl:-left-[22rem] xl:top-[1920px]">
-					<div className="hiden xl:flex justify-center xl:w-3/6 2xl:w-3/6 h-[25%] relative items-center border-2 border-deadpool-primary rounded-full bg-transparent">
-						<div className="w-[1075px] h-[100px] absolute flex items-center justify-center left-1 -mt-2 overflow-hidden">
-							<Image
-								src={deadpoolWolverine}
-								alt="Deadpool and Wolverine"
-								className="rotate-45 top-16 -left-36 relative"
-							/>
-						</div>
-					</div>
-				</div>
-				<h1 className="text-8xl md:text-[200px] lg:text-[250px] xl:text-[300px] tracking-tighter font-outline-primary text-transparent font-semibold">
-					MARVEL
-				</h1>
-			</div>
-			<div className="w-full relative flex flex-col md:flex-row md:justify-end items-center space-y-4 lg:space-y-0 md:gap-4">
-				<div className="flex justify-center items-center md:justify-end w-full md:w-auto">
-					<Image src={arrow} alt="Arrow" className="w-full relative" />
-				</div>
+  return (
+    <section className="w-11/12 mx-auto flex flex-col items-center">
+      <div className="flex flex-col">
+        <h1
+          className={`${roadRage.className} text-5xl md:text-7xl lg:text-9xl text-center`}
+        >
+          <span className="text-deadpool-accent">DEADPOOL</span> &{" "}
+          <span className="text-deadpool-secondary">WOLVERINE</span> IS JUST THE
+          BLOODY, PUERILE, HEARTFELT MOVIE WE WANTED
+        </h1>
+        <p className="text-left md:text-right text-deadpool-body relative self-start md:self-end md:mr-[7.4%]">
+          by Kyle Anderson
+        </p>
+      </div>
+      <div className="flex justify-center items-center">
+        <div className="hidden absolute xl:flex w-[700px] h-[700px] border-2 border-deadpool-body rounded-full bg-transparent items-center justify-center 2xl:-left-[20rem] 2xl:top-[1780px] xl:-left-[22rem] xl:top-[1920px]">
+          <div className="hiden xl:flex justify-center xl:w-3/6 2xl:w-3/6 h-[25%] relative items-center border-2 border-deadpool-primary rounded-full bg-transparent">
+            <div className="w-[1075px] h-[100px] absolute flex items-center justify-center left-1 -mt-2 overflow-hidden">
+              <Image
+                src={deadpoolWolverine}
+                alt="Deadpool and Wolverine"
+                className="rotate-45 top-16 -left-36 relative"
+              />
+            </div>
+          </div>
+        </div>
+        <h1 className="text-8xl md:text-[200px] lg:text-[250px] xl:text-[300px] tracking-tighter font-outline-primary text-transparent font-semibold">
+          MARVEL
+        </h1>
+      </div>
+      <div className="w-full relative flex flex-col md:flex-row md:justify-end items-center space-y-4 lg:space-y-0 md:gap-4">
+        <div className="flex justify-center items-center md:justify-end w-full md:w-auto">
+          <Image src={arrow} alt="Arrow" className="w-full relative" />
+        </div>
 
-				<div className="flex justify-center md:justify-end w-full md:w-auto space-x-2">
-					<Button className="flex justify-evenly items-center w-56 h-20 md:h-16 py-7 rounded-full text-deadpool-primary bg-[#363636] gap-3 justify-self-end">
-						<div className="left-2 p-2 bg-deadpool-primary rounded-full">
-							<PlayIcon className="size-6 fill-black text-black" />
-						</div>
+        <div className="flex justify-center md:justify-end w-full md:w-auto space-x-2">
+          <Button className="flex justify-evenly items-center w-56 h-20 md:h-16 py-7 rounded-full text-deadpool-primary bg-[#363636] gap-3 justify-self-end">
+            <div className="left-2 p-2 bg-deadpool-primary rounded-full">
+              <PlayIcon className="size-6 fill-black text-black" />
+            </div>
 
-						<div>Find Tickets</div>
-					</Button>
-					<div className="flex justify-center justify-self-center items-center">
-						<Avatar>
-							<Image src={icon1} alt="Icon1" />
-							<AvatarFallback>CN</AvatarFallback>
-						</Avatar>
-						<Avatar className="-left-2">
-							<Image src={icon2} alt="Icon2" />
-							<AvatarFallback>CN</AvatarFallback>
-						</Avatar>
-						<Avatar className="-left-4">
-							<Image src={icon3} alt="Icon3" />
-							<AvatarFallback>CN</AvatarFallback>
-						</Avatar>
-					</div>
-				</div>
-			</div>
-		</section>
-	);
+            <div>Find Tickets</div>
+          </Button>
+          <div className="flex justify-center justify-self-center items-center">
+            <Avatar>
+              <Image src={icon1} alt="Icon1" />
+              <AvatarFallback>CN</AvatarFallback>
+            </Avatar>
+            <Avatar className="-left-2">
+              <Image src={icon2} alt="Icon2" />
+              <AvatarFallback>CN</AvatarFallback>
+            </Avatar>
+            <Avatar className="-left-4">
+              <Image src={icon3} alt="Icon3" />
+              <AvatarFallback>CN</AvatarFallback>
+            </Avatar>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }
 
 export default FindTickets;

--- a/components/section/Footer.tsx
+++ b/components/section/Footer.tsx
@@ -212,7 +212,7 @@ export default function Footer() {
   );
 
   return (
-    <div className="w-screen flex flex-col text-deadpool-body bg-deadpool-neutral tracking-tighter px-[25px] lg:px-[75px] py-7">
+    <div className="w-full flex flex-col text-deadpool-body bg-deadpool-neutral tracking-tighter px-[25px] lg:px-[75px] py-7">
       {subscribeWrapper}
       <div className="w-full flex flex-col gap-24 xl:gap-0 xl:flex-row justify-between mt-32">
         {siteDetails}

--- a/components/section/HeroSection.tsx
+++ b/components/section/HeroSection.tsx
@@ -1,100 +1,107 @@
 import Image, { StaticImageData } from "next/image";
 import { MoveDown } from "lucide-react";
 import {
-	marvelStudio,
-	disney,
-	primeVid,
-	smCinema,
-	imax,
-	vista,
-	netflix,
+  marvelStudio,
+  disney,
+  primeVid,
+  smCinema,
+  imax,
+  vista,
+  netflix,
 } from "../constants/images";
 import { Button } from "../ui/button";
 import Link from "next/link";
 
 type Images = {
-	source: StaticImageData;
-	altText: string;
+  source: StaticImageData;
+  altText: string;
 };
 
 const cinemaImages: Images[] = [
-	{ source: disney, altText: "Disney Plus" },
-	{ source: primeVid, altText: "Prime Video" },
-	{ source: netflix, altText: "Netflix" },
+  { source: disney, altText: "Disney Plus" },
+  { source: primeVid, altText: "Prime Video" },
+  { source: netflix, altText: "Netflix" },
 ];
 
 const cinemaImages2: Images[] = [
-	{ source: smCinema, altText: "SM Cinema" },
-	{ source: imax, altText: "IMAX" },
-	{ source: vista, altText: "Vista" },
+  { source: smCinema, altText: "SM Cinema" },
+  { source: imax, altText: "IMAX" },
+  { source: vista, altText: "Vista" },
 ];
 
 function HeroSection() {
-	return (
-		<section
-			className="w-screen h-screen bg-deadpool-dark bg-cover bg-center flex flex-col justify-center items-center"
-			id="#home"
-		>
-			<div className="w-11/12 h-1/6 flex justify-start items-center mt-8">
-				<p className="text-[16px] text-left px-3 md:px-1 leading-6 mt-10">
-					Premiered on July 22, 2024
-				</p>
-			</div>
-			<div className="w-11/12 flex justify-start">
-				<div className="w-4/5 md:w-3/6 px-3 md:px-1 flex flex-col">
-					<Image src={marvelStudio} alt="Marvel logo" className="relative -left-1" />
-					<h1 className="text-5xl md:text-6xl font-bold">DEADPOOL</h1>
-					<h1 className="py-2 md:py-0 text-5xl md:text-6xl font-bold flex">
-						<span className=" text-4xl md:text-5xl text-transparent font-outline-secondary leading-8 md:leading-snug">
-							&
-						</span>
-						<span className="text-transparent font-outline-primary">WOLVERINE</span>
-					</h1>
-					<p className="text-wrap">
-						&quot;Deadpool & Wolverine&quot; is a 2024 superhero film featuring the
-						Marvel characters, produced by Marvel Studios and distributed by Disney.
-					</p>
-					<div className="flex gap-5 py-8">
-						<Button variant={"secondary"} className="rounded-full" size={"lg"}>
-							Onsale Tickets
-						</Button>
-						<Button variant={"outline"} className="rounded-full" size={"lg"}>
-							Trailer
-						</Button>
-					</div>
-				</div>
-			</div>
-			<div className="w-11/12 h-2/6 flex flex-col lg:flex-row lg:justify-between lg:items-center">
-				<div className="relative h-2/6 lg:w-2/6 flex justify-between items-center px-2">
-					{cinemaImages.map(({ source, altText }, idx) => (
-						<div key={idx}>
-							<Image src={source} alt={altText} width={125} height={100} />
-						</div>
-					))}
-				</div>
+  return (
+    <section
+      className="w-full h-screen bg-deadpool-dark bg-cover bg-center flex flex-col justify-center items-center"
+      id="#home"
+    >
+      <div className="w-11/12 h-1/6 flex justify-start items-center mt-8">
+        <p className="text-[16px] text-left px-3 md:px-1 leading-6 mt-10">
+          Premiered on July 22, 2024
+        </p>
+      </div>
+      <div className="w-11/12 flex justify-start">
+        <div className="w-4/5 md:w-3/6 px-3 md:px-1 flex flex-col">
+          <Image
+            src={marvelStudio}
+            alt="Marvel logo"
+            className="relative -left-1"
+          />
+          <h1 className="text-5xl md:text-6xl font-bold">DEADPOOL</h1>
+          <h1 className="py-2 md:py-0 text-5xl md:text-6xl font-bold flex">
+            <span className=" text-4xl md:text-5xl text-transparent font-outline-secondary leading-8 md:leading-snug">
+              &
+            </span>
+            <span className="text-transparent font-outline-primary">
+              WOLVERINE
+            </span>
+          </h1>
+          <p className="text-wrap">
+            &quot;Deadpool & Wolverine&quot; is a 2024 superhero film featuring
+            the Marvel characters, produced by Marvel Studios and distributed by
+            Disney.
+          </p>
+          <div className="flex gap-5 py-8">
+            <Button variant={"secondary"} className="rounded-full" size={"lg"}>
+              Onsale Tickets
+            </Button>
+            <Button variant={"outline"} className="rounded-full" size={"lg"}>
+              Trailer
+            </Button>
+          </div>
+        </div>
+      </div>
+      <div className="w-11/12 h-2/6 flex flex-col lg:flex-row lg:justify-between lg:items-center">
+        <div className="relative h-2/6 lg:w-2/6 flex justify-between items-center px-2">
+          {cinemaImages.map(({ source, altText }, idx) => (
+            <div key={idx}>
+              <Image src={source} alt={altText} width={125} height={100} />
+            </div>
+          ))}
+        </div>
 
-				<div className="h-2/6 flex flex-col justify-evenly items-center p-1 order-3 lg:order-none">
-					<Button
-						size={"lg"}
-						variant={"default"}
-						className="w-16 h-20 md:h-24 lg:h-28 xl:h-16 p-0 rounded-full flex items-center justify-center"
-					>
-						<Link href="#sneakpeek">
-							<MoveDown className="text-deadpool-secondary" size={25} />
-						</Link>
-					</Button>
-					<p className="text-center">Scroll Down</p>
-				</div>
-				<div className="relative h-2/6 lg:w-2/6 flex justify-between items-center px-2">
-					{cinemaImages2.map(({ source, altText }, idx) => (
-						<div key={idx}>
-							<Image src={source} alt={altText} width={125} height={100} />
-						</div>
-					))}
-				</div>
-			</div>
-		</section>
-	);
+        <div className="h-2/6 flex flex-col justify-evenly items-center p-1 order-3 lg:order-none">
+          <Button
+            size={"lg"}
+            variant={"default"}
+            className="w-16 h-20 md:h-24 lg:h-28 xl:h-16 p-0 rounded-full flex items-center justify-center"
+          >
+            <Link href="#sneakpeek">
+              <MoveDown className="text-deadpool-secondary" size={25} />
+            </Link>
+          </Button>
+          <p className="text-center">Scroll Down</p>
+        </div>
+        <div className="relative h-2/6 lg:w-2/6 flex justify-between items-center px-2">
+          {cinemaImages2.map(({ source, altText }, idx) => (
+            <div key={idx}>
+              <Image src={source} alt={altText} width={125} height={100} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 }
 
 export default HeroSection;

--- a/components/section/MarvelTalk.tsx
+++ b/components/section/MarvelTalk.tsx
@@ -126,151 +126,149 @@ function MarvelTalk() {
   const columns = splitArray(MARVEL_TALK, 2);
 
   return (
-    <MaxWidthWrapper className="max-w-screen-2xl">
-      <div
-        id="marveltalk"
-        className="w-full mt-24 mb-10 space-y-4 md:space-y-6 md:my-24 lg:mt-64 xl:mb-16 xl:mt-[32rem]"
-      >
-        <div className="space-y-1.5 md:space-y-2">
-          <h1 className="-tracking-tighter text-2xl md:text-4xl font-medium">
-            Marvel&apos;s Talk
-          </h1>
-          <p className="text-xs md:text-sm font-light -tracking-tighter">
-            Your source for the latest in Marvel Cinematics.
-          </p>
-        </div>
-        <div className="md:hidden flex items-center justify-center gap-4 w-max ml-auto mt-8">
-          <span className="text-sm">SWIPE RIGHT</span>
-          <Button className="size-12 rounded-full border-none bg-[#141311] hover:!bg-stone-700 focus:!bg-stone-700">
-            <ArrowRight className="size-5 md:size-6 text-deadpool-secondary" />
-          </Button>
-        </div>
-        <div className="relative max-w-sm md:max-w-3xl xl:max-w-screen-xl">
-          <div
-            className="hidden md:block absolute left-0 w-1/6 inset-y-0 z-10 pointer-events-none"
-            style={{
-              background:
-                "linear-gradient(to right, #080808, rgba(8, 8, 8, 0))",
-            }}
-          />
-          <div
-            className="hidden md:block absolute right-0 w-1/6 inset-y-0 z-10 pointer-events-none"
-            style={{
-              background: "linear-gradient(to left, #080808, rgba(8, 8, 8, 0))",
-            }}
-          />
-          <Swiper
-            className=""
-            modules={[A11y]}
-            breakpoints={{
-              320: {
-                slidesPerView: 1,
-                spaceBetween: 15,
-              },
-              640: {
-                slidesPerView: 1.4,
-                spaceBetween: 15,
-              },
-              768: {
-                slidesPerView: 2.2,
-                spaceBetween: 15,
-              },
-              1024: {
-                slidesPerView: 3,
-                spaceBetween: 20,
-              },
-            }}
-          >
-            {columns[0].map((v, index) => (
-              <SwiperSlide key={index}>
-                <Card className="bg-[#141311] h-52 flex items-center justify-center space-x-4 m-2 w-full rounded-lg overflow-hidden shadow-none border-none px-4 py-2 ">
-                  <Avatar className="size-14">
-                    <AvatarImage className="object-cover" src={v.imgSrc} />
-                    <AvatarFallback>CN</AvatarFallback>
-                  </Avatar>
-                  <div className="flex flex-col justify-center w-full">
-                    <CardHeader className="flex-row items-center gap-1.5 md:gap-2 px-0 py-2">
-                      <CardTitle className="text-xl md:text-2xl text-deadpool-secondary">
-                        {v.author}
-                      </CardTitle>
-
-                      <Circle className="size-1.5 text-[#3e3b36] !fill-[#3e3b36]" />
-                      <CardDescription>{v.timeStamp}</CardDescription>
-                    </CardHeader>
-                    <CardContent className="p-0 w-full">
-                      <p className="text-white text-pretty text-xs md:text-sm -tracking-tighter">
-                        {v.content}
-                      </p>
-                    </CardContent>
-                  </div>
-                </Card>
-              </SwiperSlide>
-            ))}
-          </Swiper>
-        </div>
-        <div className="relative max-w-sm md:max-w-3xl xl:max-w-screen-xl">
-          <div
-            className="hidden md:block absolute left-0 w-1/6 inset-y-0 z-10 pointer-events-none"
-            style={{
-              background:
-                "linear-gradient(to right, #080808, rgba(8, 8, 8, 0))",
-            }}
-          />
-          <div
-            className="hidden md:block absolute right-0 w-1/6 inset-y-0 z-10 pointer-events-none"
-            style={{
-              background: "linear-gradient(to left, #080808, rgba(8, 8, 8, 0))",
-            }}
-          />
-          <Swiper
-            modules={[A11y]}
-            breakpoints={{
-              320: {
-                slidesPerView: 1.2,
-                spaceBetween: 15,
-              },
-              640: {
-                slidesPerView: 1.4,
-                spaceBetween: 15,
-              },
-              768: {
-                slidesPerView: 2.4,
-                spaceBetween: 15,
-              },
-              1024: {
-                slidesPerView: 3.4,
-                spaceBetween: 20,
-              },
-            }}
-          >
-            {columns[1].map((v, index) => (
-              <SwiperSlide key={index}>
-                <Card className="bg-[#141311] h-56 flex items-center justify-center space-x-4 m-2 w-full rounded-lg overflow-hidden shadow-none border-none px-4 py-2 ">
-                  <Avatar className="size-14">
-                    <AvatarImage className="object-cover" src={v.imgSrc} />
-                    <AvatarFallback>CN</AvatarFallback>
-                  </Avatar>
-                  <div className="flex flex-col justify-center w-full">
-                    <CardHeader className="flex-row items-center gap-1.5 md:gap-2 px-0 py-2">
-                      <CardTitle className="text-xl md:text-2xl text-deadpool-secondary">
-                        {v.author}
-                      </CardTitle>
-                      <Circle className="size-1.5 text-[#3e3b36] !fill-[#3e3b36]" />
-                      <CardDescription>{v.timeStamp}</CardDescription>
-                    </CardHeader>
-                    <CardContent className="p-0 w-full">
-                      <p className="text-white text-pretty text-xs md:text-sm -tracking-tighter">
-                        {v.content}
-                      </p>
-                    </CardContent>
-                  </div>
-                </Card>
-              </SwiperSlide>
-            ))}
-          </Swiper>
-        </div>
+    // <MaxWidthWrapper className="max-w-screen-2xl">
+    <div
+      id="marveltalk"
+      className="w-full mt-24 mb-10 space-y-4 md:space-y-6 md:my-24 lg:mt-64 xl:mb-16 xl:mt-[32rem] px-[25px] lg:px-[75px]"
+    >
+      <div className="space-y-1.5 md:space-y-2">
+        <h1 className="-tracking-tighter text-2xl md:text-4xl font-medium">
+          Marvel&apos;s Talk
+        </h1>
+        <p className="text-xs md:text-sm font-light -tracking-tighter">
+          Your source for the latest in Marvel Cinematics.
+        </p>
       </div>
-    </MaxWidthWrapper>
+      <div className="md:hidden flex items-center justify-center gap-4 w-max ml-auto mt-8">
+        <span className="text-sm">SWIPE RIGHT</span>
+        <Button className="size-12 rounded-full border-none bg-[#141311] hover:!bg-stone-700 focus:!bg-stone-700">
+          <ArrowRight className="size-5 md:size-6 text-deadpool-secondary" />
+        </Button>
+      </div>
+      <div className="relative max-w-sm md:max-w-3xl xl:max-w-screen-xl">
+        <div
+          className="hidden md:block absolute left-0 w-1/6 inset-y-0 z-10 pointer-events-none"
+          style={{
+            background: "linear-gradient(to right, #080808, rgba(8, 8, 8, 0))",
+          }}
+        />
+        <div
+          className="hidden md:block absolute right-0 w-1/6 inset-y-0 z-10 pointer-events-none"
+          style={{
+            background: "linear-gradient(to left, #080808, rgba(8, 8, 8, 0))",
+          }}
+        />
+        <Swiper
+          className=""
+          modules={[A11y]}
+          breakpoints={{
+            320: {
+              slidesPerView: 1,
+              spaceBetween: 15,
+            },
+            640: {
+              slidesPerView: 1.4,
+              spaceBetween: 15,
+            },
+            768: {
+              slidesPerView: 2.2,
+              spaceBetween: 15,
+            },
+            1024: {
+              slidesPerView: 3,
+              spaceBetween: 20,
+            },
+          }}
+        >
+          {columns[0].map((v, index) => (
+            <SwiperSlide key={index}>
+              <Card className="bg-[#141311] h-52 flex items-center justify-center space-x-4 m-2 w-full rounded-lg overflow-hidden shadow-none border-none px-4 py-2 ">
+                <Avatar className="size-14">
+                  <AvatarImage className="object-cover" src={v.imgSrc} />
+                  <AvatarFallback>CN</AvatarFallback>
+                </Avatar>
+                <div className="flex flex-col justify-center w-full">
+                  <CardHeader className="flex-row items-center gap-1.5 md:gap-2 px-0 py-2">
+                    <CardTitle className="text-xl md:text-2xl text-deadpool-secondary">
+                      {v.author}
+                    </CardTitle>
+
+                    <Circle className="size-1.5 text-[#3e3b36] !fill-[#3e3b36]" />
+                    <CardDescription>{v.timeStamp}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="p-0 w-full">
+                    <p className="text-white text-pretty text-xs md:text-sm -tracking-tighter">
+                      {v.content}
+                    </p>
+                  </CardContent>
+                </div>
+              </Card>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+      <div className="relative max-w-sm md:max-w-3xl xl:max-w-screen-xl">
+        <div
+          className="hidden md:block absolute left-0 w-1/6 inset-y-0 z-10 pointer-events-none"
+          style={{
+            background: "linear-gradient(to right, #080808, rgba(8, 8, 8, 0))",
+          }}
+        />
+        <div
+          className="hidden md:block absolute right-0 w-1/6 inset-y-0 z-10 pointer-events-none"
+          style={{
+            background: "linear-gradient(to left, #080808, rgba(8, 8, 8, 0))",
+          }}
+        />
+        <Swiper
+          modules={[A11y]}
+          breakpoints={{
+            320: {
+              slidesPerView: 1.2,
+              spaceBetween: 15,
+            },
+            640: {
+              slidesPerView: 1.4,
+              spaceBetween: 15,
+            },
+            768: {
+              slidesPerView: 2.4,
+              spaceBetween: 15,
+            },
+            1024: {
+              slidesPerView: 3.4,
+              spaceBetween: 20,
+            },
+          }}
+        >
+          {columns[1].map((v, index) => (
+            <SwiperSlide key={index}>
+              <Card className="bg-[#141311] h-56 flex items-center justify-center space-x-4 m-2 w-full rounded-lg overflow-hidden shadow-none border-none px-4 py-2 ">
+                <Avatar className="size-14">
+                  <AvatarImage className="object-cover" src={v.imgSrc} />
+                  <AvatarFallback>CN</AvatarFallback>
+                </Avatar>
+                <div className="flex flex-col justify-center w-full">
+                  <CardHeader className="flex-row items-center gap-1.5 md:gap-2 px-0 py-2">
+                    <CardTitle className="text-xl md:text-2xl text-deadpool-secondary">
+                      {v.author}
+                    </CardTitle>
+                    <Circle className="size-1.5 text-[#3e3b36] !fill-[#3e3b36]" />
+                    <CardDescription>{v.timeStamp}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="p-0 w-full">
+                    <p className="text-white text-pretty text-xs md:text-sm -tracking-tighter">
+                      {v.content}
+                    </p>
+                  </CardContent>
+                </div>
+              </Card>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+    </div>
+    // </MaxWidthWrapper>
   );
 }
 

--- a/components/section/SneakPeek.tsx
+++ b/components/section/SneakPeek.tsx
@@ -15,86 +15,85 @@ function SneakPeek() {
   const swiperRef = useRef<SwiperType | null>();
 
   return (
-    <MaxWidthWrapper className="mt-24 mb-32">
-      <div
-        className="flex flex-col lg:flex-row md:justify-between gap-10"
-        id="sneakpeek"
-      >
-        <div className="flex flex-col space-y-6">
-          <h2 className="text-2xl font-semibold max-w-prose text-pretty leading-9">
-            Deadpool & Wolverine is a 2024 American superhero film based on
-            Marvel Comics 
-          </h2>
-          <p className="text-sm text-stone-300 -tracking-tighter leading-5 text-pretty max-w-prose">
-            Featuring the characters Deadpool and Wolverine, produced by Marvel
-            Studios. The film received generally positive reviews from critics
-            and has grossed over $211 million worldwide.
-          </p>
+    // <MaxWidthWrapper className="mt-24 mb-32">
+    <div
+      className="flex flex-col lg:flex-row md:justify-between gap-10 p-[25px] lg:pl-[75px] mt-24 mb-32"
+      id="sneakpeek"
+    >
+      <div className="flex flex-col space-y-6">
+        <h2 className="text-2xl font-semibold max-w-prose text-pretty leading-9">
+          Deadpool & Wolverine is a 2024 American superhero film based on Marvel
+          Comics 
+        </h2>
+        <p className="text-sm text-stone-300 -tracking-tighter leading-5 text-pretty max-w-prose">
+          Featuring the characters Deadpool and Wolverine, produced by Marvel
+          Studios. The film received generally positive reviews from critics and
+          has grossed over $211 million worldwide.
+        </p>
 
+        <Button
+          size={"lg"}
+          className="relative rounded-full bg-[#363636] w-max text-xs font-light py-7"
+        >
+          <div className="absolute left-2 p-2 bg-deadpool-primary rounded-full">
+            <PlayIcon className="size-6 fill-black text-black" />
+          </div>
+          <span className="ml-8">Watch Stream & Trailer</span>
+        </Button>
+      </div>
+      <div className="relative mx-auto max-w-xs sm:max-w-lg md:max-w-xl">
+        <div
+          className="absolute left-0 w-full inset-y-0 z-10 pointer-events-none"
+          style={{
+            background: "linear-gradient(to right, #080808, rgba(8, 8, 8, 0))",
+          }}
+        />
+        <Swiper
+          modules={[A11y]}
+          breakpoints={{
+            320: {
+              slidesPerView: 1,
+              spaceBetween: 10,
+            },
+            640: {
+              slidesPerView: 1.5,
+              spaceBetween: 20,
+            },
+          }}
+          onSwiper={(swiper) => (swiperRef.current = swiper)}
+          onSliderMove={() => {
+            if (isEnd) {
+              setIsEnd(false);
+            }
+          }}
+          onReachEnd={() => setIsEnd(true)}
+        >
+          {Array.from({ length: 4 }).map((_, index) => (
+            <SwiperSlide key={index}>
+              <Card className="m-2 relative aspect-[4/5] rounded-[60px] overflow-hidden shadow-none border-none">
+                <Image
+                  src={`/sneak-peek/${index + 1}.png`}
+                  alt=""
+                  fill
+                  className="object-cover"
+                />
+              </Card>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+        <div className="flex items-center justify-center gap-4 w-max ml-auto mt-8">
+          <span className="text-sm">SWIPE RIGHT</span>
           <Button
-            size={"lg"}
-            className="relative rounded-full bg-[#363636] w-max text-xs font-light py-7"
+            disabled={isEnd}
+            className="size-12 rounded-full border-none bg-[#141311] hover:!bg-stone-700 focus:!bg-stone-700"
+            onClick={() => swiperRef.current?.slideNext()}
           >
-            <div className="absolute left-2 p-2 bg-deadpool-primary rounded-full">
-              <PlayIcon className="size-6 fill-black text-black" />
-            </div>
-            <span className="ml-8">Watch Stream & Trailer</span>
+            <ArrowRight className="size-5 md:size-6 text-deadpool-secondary" />
           </Button>
         </div>
-        <div className="relative mx-auto max-w-xs sm:max-w-lg md:max-w-xl">
-          <div
-            className="absolute left-0 w-full inset-y-0 z-10 pointer-events-none"
-            style={{
-              background:
-                "linear-gradient(to right, #080808, rgba(8, 8, 8, 0))",
-            }}
-          />
-          <Swiper
-            modules={[A11y]}
-            breakpoints={{
-              320: {
-                slidesPerView: 1,
-                spaceBetween: 10,
-              },
-              640: {
-                slidesPerView: 1.5,
-                spaceBetween: 20,
-              },
-            }}
-            onSwiper={(swiper) => (swiperRef.current = swiper)}
-            onSliderMove={() => {
-              if (isEnd) {
-                setIsEnd(false);
-              }
-            }}
-            onReachEnd={() => setIsEnd(true)}
-          >
-            {Array.from({ length: 4 }).map((_, index) => (
-              <SwiperSlide key={index}>
-                <Card className="m-2 relative aspect-[4/5] rounded-[60px] overflow-hidden shadow-none border-none">
-                  <Image
-                    src={`/sneak-peek/${index + 1}.png`}
-                    alt=""
-                    fill
-                    className="object-cover"
-                  />
-                </Card>
-              </SwiperSlide>
-            ))}
-          </Swiper>
-          <div className="flex items-center justify-center gap-4 w-max ml-auto mt-8">
-            <span className="text-sm">SWIPE RIGHT</span>
-            <Button
-              disabled={isEnd}
-              className="size-12 rounded-full border-none bg-[#141311] hover:!bg-stone-700 focus:!bg-stone-700"
-              onClick={() => swiperRef.current?.slideNext()}
-            >
-              <ArrowRight className="size-5 md:size-6 text-deadpool-secondary" />
-            </Button>
-          </div>
-        </div>
       </div>
-    </MaxWidthWrapper>
+    </div>
+    // </MaxWidthWrapper>
   );
 }
 


### PR DESCRIPTION
- page.tsx -> set width to occupy 100% of screen width, wrapped all components inside MaxWidthWrapper.
- MaxWidthWrapper -> set max width to `1440px` as per Figma measurements
- NavBar -> changed to `w-full`
- HeroSection -> changed `w-screen` to `w-full`; need to set tracking to `tracking-tighter`
- SneakPeek -> removed MaxWidthWrapper, added paddings on first div
- FindTickets -> added `mx-auto`; need to check tracking
- MarvelTalk -> removed MaxWidthWrapper, added paddings on first div
- ArticlesToRead -> changed `w-screen` to `w-full`
- Cast -> added `mx-auto`; need to change text-alignment on `sm` view
- Footer -> changed `w-screen` to `w-full`

Before: (has an extra horizontal scroll beyond viewport width)
![image](https://github.com/user-attachments/assets/3c55e421-841f-4575-9595-48388350e0e5)

After: (no more horizontal scrollbar)
![image](https://github.com/user-attachments/assets/e397cbbb-69cd-445c-bec0-52565206e561)

Before: (no max-width)
![image](https://github.com/user-attachments/assets/56220adf-1a71-46c2-a001-b06659616b3a)

After: (max-width at 1440px based on Figma dimensions)
![image](https://github.com/user-attachments/assets/f01987f7-4dd8-403e-a5a5-73d16ec95352)

